### PR TITLE
jsclasses.dtx: Improve \everyparhook (#12)

### DIFF
--- a/jsclasses.dtx
+++ b/jsclasses.dtx
@@ -5110,10 +5110,25 @@
 %    \begin{macrocode}
 \def\@inhibitglue{%
   \futurelet\@let@token\@@inhibitglue}
-\edef\jsc@kanji@character{\detokenize{kanji character }}
+\begingroup
+\let\GDEF=\gdef
+\let\CATCODE=\catcode
+\let\ENDGROUP=\endgroup
+\CATCODE`k=12
+\CATCODE`a=12
+\CATCODE`n=12
+\CATCODE`j=12
+\CATCODE`i=12
+\CATCODE`c=12
+\CATCODE`h=12
+\CATCODE`r=12
+\CATCODE`t=12
+\CATCODE`e=12
+\GDEF\KANJI@CHARACTER{kanji character }
+\ENDGROUP
 \def\@@inhibitglue{%
-  \expandafter\expandafter\expandafter\jsc@inhibitglue\expandafter\meaning\expandafter\@let@token\jsc@kanji@character\relax\jsc@end}
-\expandafter\def\expandafter\jsc@inhibitglue\expandafter#\expandafter1\jsc@kanji@character#2#3\jsc@end{%
+  \expandafter\expandafter\expandafter\jsc@inhibitglue\expandafter\meaning\expandafter\@let@token\KANJI@CHARACTER\relax\jsc@end}
+\expandafter\def\expandafter\jsc@inhibitglue\expandafter#\expandafter1\KANJI@CHARACTER#2#3\jsc@end{%
   \def\@tempa{#1}%
   \ifx\@tempa\@empty
     \ifnum\the\inhibitxspcode`#2=2\relax

--- a/jsclasses.dtx
+++ b/jsclasses.dtx
@@ -5110,20 +5110,14 @@
 %    \begin{macrocode}
 \def\@inhibitglue{%
   \futurelet\@let@token\@@inhibitglue}
+\edef\jsc@kanji@character{\detokenize{kanji character }}
 \def\@@inhibitglue{%
-  \ifx\@let@token「
-    \inhibitglue
-  \else
-    \ifx\@let@token（
+  \expandafter\expandafter\expandafter\jsc@inhibitglue\expandafter\meaning\expandafter\@let@token\jsc@kanji@character\relax\jsc@end}
+\expandafter\def\expandafter\jsc@inhibitglue\expandafter#\expandafter1\jsc@kanji@character#2#3\jsc@end{%
+  \def\@tempa{#1}%
+  \ifx\@tempa\@empty
+    \ifnum\the\inhibitxspcode`#2=2\relax
       \inhibitglue
-    \else
-      \ifx\@let@token『
-        \inhibitglue
-      \else
-        \ifx\@let@token［
-          \inhibitglue
-        \fi
-      \fi
     \fi
   \fi}
 \let\everyparhook=\@inhibitglue


### PR DESCRIPTION
#12 での[ZRさんのアイデア](https://github.com/texjporg/jsclasses/issues/12#issuecomment-232867611)に則り，`\inhibitxspcode` が 2 であるような和文文字が段落冒頭文字である場合に `\inhibitglue` を発行するようにしてみました。
（ちょっとトリッキーなコードになってしまいましたが……。）