### PR TITLE
jsclasses.dtx: fix value of \jsc@magscale for 8pt

### DIFF
--- a/jsclasses.dtx
+++ b/jsclasses.dtx
@@ -316,7 +316,7 @@
   \@slidetrue\def\jsc@magscale{3.583}
   \renewcommand{\@ptsize}{26}
   \@landscapetrue\@titlepagetrue}
-\DeclareOption{8pt}{\def\jsc@magscale{0.83}\renewcommand{\@ptsize}{-2}}
+\DeclareOption{8pt}{\def\jsc@magscale{0.833}\renewcommand{\@ptsize}{-2}}
 \DeclareOption{9pt}{\def\jsc@magscale{0.913}\renewcommand{\@ptsize}{-1}}
 \DeclareOption{10pt}{\def\jsc@magscale{1}\renewcommand{\@ptsize}{0}}
 \DeclareOption{11pt}{\def\jsc@magscale{1.095}\renewcommand{\@ptsize}{1}}


### PR DESCRIPTION
8pt のときの \jsc@magscale の値が実際の \mag の値と整合していなかったので修正しました。