### PR TITLE
jsclasses.dtx: \subsubsection for slide (#27)

### DIFF
--- a/jsclasses.dtx
+++ b/jsclasses.dtx
@@ -2849,6 +2849,9 @@
 % 二つ挿入した |\everyparhook| のうち後者が |\paragraph| 類の後で2回実行され，
 % それ以降は前者が実行されます。
 %
+% [2016-07-28] \texttt{slide}オプションと\texttt{twocolumn}オプションを
+% 同時に指定した場合の罫線の位置を微調整しました。
+%
 %    \begin{macrocode}
 \def\@xsect#1{%
 % 見出しの後ろの空きを \@tempskipa にセット

--- a/jsclasses.dtx
+++ b/jsclasses.dtx
@@ -3422,7 +3422,7 @@
 \else
   \newcommand{\subsubsection}{\@startsection{subsubsection}{3}{\z@}%
     {\Cvs \@plus.5\Cdp \@minus.2\Cdp}%
-    {\z@}%
+    {\if@slide .5\Cvs \@plus.3\Cdp \else \z@ \fi}%
     {\normalfont\normalsize\headfont}}
 \fi
 %    \end{macrocode}

--- a/jsclasses.dtx
+++ b/jsclasses.dtx
@@ -3414,6 +3414,10 @@
 % \end{macro}
 %
 % \begin{macro}{\subsubsection}
+%
+% [2016-07-22] \texttt{slide}オプション指定時に |\subsubsection| の文字列
+% と罫線が重なる問題に対処しました(forum:1982)。
+%
 %    \begin{macrocode}
 \if@twocolumn
   \newcommand{\subsubsection}{\@startsection{subsubsection}{3}{\z@}%

--- a/jsclasses.dtx
+++ b/jsclasses.dtx
@@ -3401,7 +3401,7 @@
 %    \begin{macrocode}
 \if@twocolumn
   \newcommand{\subsection}{\@startsection{subsection}{2}{\z@}%
-    {\z@}{\z@}%
+    {\z@}{\if@slide .4\Cvs \else \z@ \fi}%
     {\normalfont\normalsize\headfont}}
 \else
   \newcommand{\subsection}{\@startsection{subsection}{2}{\z@}%
@@ -3421,7 +3421,7 @@
 %    \begin{macrocode}
 \if@twocolumn
   \newcommand{\subsubsection}{\@startsection{subsubsection}{3}{\z@}%
-    {\z@}{\z@}%
+    {\z@}{\if@slide .4\Cvs \else \z@ \fi}%
     {\normalfont\normalsize\headfont}}
 \else
   \newcommand{\subsubsection}{\@startsection{subsubsection}{3}{\z@}%
@@ -3439,13 +3439,13 @@
 %    \begin{macrocode}
 \if@twocolumn
   \newcommand{\paragraph}{\@startsection{paragraph}{4}{\z@}%
-    {\z@}{-1zw}% 改行せず 1zw のアキ
+    {\z@}{\if@slide .4\Cvs \else -1zw\fi}% 改行せず 1zw のアキ
 %<jspf>    {\normalfont\normalsize\headfont}}
 %<!jspf>    {\normalfont\normalsize\headfont ■}}
 \else
   \newcommand{\paragraph}{\@startsection{paragraph}{4}{\z@}%
     {0.5\Cvs \@plus.5\Cdp \@minus.2\Cdp}%
-    {-1zw}% 改行せず 1zw のアキ
+    {\if@slide .5\Cvs \@plus.3\Cdp \else -1zw\fi}% 改行せず 1zw のアキ
 %<jspf>    {\normalfont\normalsize\headfont}}
 %<!jspf>    {\normalfont\normalsize\headfont ■}}
 \fi
@@ -3457,9 +3457,15 @@
 %    見出しの後ろで改行されません。
 %
 %    \begin{macrocode}
-\newcommand{\subparagraph}{\@startsection{subparagraph}{5}{\z@}%
-   {\z@}{-1zw}%
-   {\normalfont\normalsize\headfont}}
+\if@twocolumn
+  \newcommand{\subparagraph}{\@startsection{subparagraph}{5}{\z@}%
+    {\z@}{\if@slide .4\Cvs \@plus.3\Cdp \else -1zw\fi}%
+    {\normalfont\normalsize\headfont}}
+\else
+  \newcommand{\subparagraph}{\@startsection{subparagraph}{5}{\z@}%
+    {\z@}{\if@slide .5\Cvs \@plus.3\Cdp \else -1zw\fi}%
+    {\normalfont\normalsize\headfont}}
+\fi
 %    \end{macrocode}
 % \end{macro}
 %

--- a/jsclasses.dtx
+++ b/jsclasses.dtx
@@ -2876,7 +2876,9 @@
     \@afterheading
   \fi
   \if@slide
-    {\vskip-6\jsc@mpt\maybeblue\hrule height0\jsc@mpt depth1\jsc@mpt\vskip7\jsc@mpt\relax}%
+    {\vskip\if@twocolumn-5\jsc@mpt\else-6\jsc@mpt\fi
+     \maybeblue\hrule height0\jsc@mpt depth1\jsc@mpt
+     \vskip\if@twocolumn 4\jsc@mpt\else 7\jsc@mpt\fi\relax}%
   \fi
   \par  % 2000-12-18
   \ignorespaces}


### PR DESCRIPTION
#27 の修正です。

（もし slide オプションを twocolumn オプションと併用することを想定するなら、`\if@twocolumn` が真の定義にも同様の処置を施すとよいのかもしれませんが、今回は入れていません）