### PR TITLE
Avoid conflict with ascmac (#30)

### DIFF
--- a/okumacro.dtx
+++ b/okumacro.dtx
@@ -156,6 +156,9 @@
 %
 % \kenten{圏点}を振るコマンドです。
 %
+% [2016-07-30] ルビと圏点の高さを合わせるつもりでしたが，間違って
+% 上シフト量を0.63zwとしていましたので，正しい値0.75zwに直しました。
+%
 %    \begin{macrocode}
 \def\kenten#1{%
   \ifvmode\leavevmode\else\hskip\kanjiskip\fi
@@ -164,7 +167,7 @@
   \@kenten#1\end}
 \def\@kenten#1{%
   \ifx#1\end \let\next=\relax \else
-    \raise.63zw\copy1\nobreak #1\hskip\kanjiskip\relax
+    \raise.75zw\copy1\nobreak #1\hskip\kanjiskip\relax
     \let\next=\@kenten
   \fi\next}
 %    \end{macrocode}

--- a/okumacro.dtx
+++ b/okumacro.dtx
@@ -387,7 +387,11 @@
 %
 % これを使ってキートップ記号を作ります。
 %
+% [2016-07-30] |\keytop| はp\LaTeX のascmacパッケージ(tascmac.sty)でも
+% 定義されていますので，tascmac.styが読み込み済みの場合は定義しないことにします。
+%
 %    \begin{macrocode}
+\expandafter\ifx\csname ver@tascmac.sty\endcsname\relax
 \newcommand{\keytop}[1]{{\leavevmode\kern1pt
   \setbox1=\hbox{\normalfont\sffamily [}%
   \dimen1=\ht1
@@ -410,6 +414,7 @@
     \put(\tempB,\tempC){\oval(\tempA,4)[t]}
     \put(\tempB,0){\makebox(0,0)[b]{\box0}}
   \end{picture}\kern1pt}}
+\fi
 %    \end{macrocode}
 % \end{macro}
 %
@@ -417,7 +422,11 @@
 %
 % リターンキーの記号です。
 %
+% [2016-07-30] |\return| はp\LaTeX のascmacパッケージ(tascmac.sty)でも
+% 定義されていますので，tascmac.styが読み込み済みの場合は定義しないことにします。
+%
 %    \begin{macrocode}
+\expandafter\ifx\csname ver@tascmac.sty\endcsname\relax
 \def\RETMARK{{\unitlength=1pt
   \setbox0=\hbox{\normalfont\ttfamily [}%
   \dimen0=\ht0
@@ -429,6 +438,7 @@
     \put(\tempA,1){\vector(-1,0){\tempA}}
   \end{picture}}}
 \newcommand{\return}{\keytop{\RETMARK}}
+\fi
 %    \end{macrocode}
 % \end{macro}
 %
@@ -728,7 +738,14 @@
 % ただ，screen環境の最初に |[| が来る場合は誤動作しますので，|\relax|
 % か |{}| を入れて誤魔化してください。
 %
+% [2016-07-30] 元になっているp\LaTeX のascmacパッケージ(tascmac.sty)と
+% 衝突しないように，tascmac.styが読み込み済みの場合は定義しないことにします。
+% ascmacパッケージのscreen環境は，オプション引数の数値で角の丸みの大きさを
+% 整数値(0--8)で指定しますが，okumacroパッケージのscreen環境は横の倍率を
+% 指定するという違いがあります。
+%
 %    \begin{macrocode}
+\expandafter\ifx\csname ver@tascmac.sty\endcsname\relax
 \newdimen\@scw
 \newbox\scb@x
 \newenvironment{screen}[1][1]%
@@ -751,6 +768,7 @@
                  \else\scalebox{\screensc@le}[1]{\box\scb@x}\fi}
     \end{picture}%
   \end{flushleft}}
+\fi
 %    \end{macrocode}
 % \end{environment}
 %
@@ -847,7 +865,11 @@
 %
 % 影付きの箱です。|ascmac.sty| から取りました。
 %
+% [2016-07-30] 元になっているp\LaTeX のascmacパッケージ(tascmac.sty)と
+% 衝突しないように，tascmac.styが読み込み済みの場合は定義しないことにします。
+%
 %    \begin{macrocode}
+\expandafter\ifx\csname ver@tascmac.sty\endcsname\relax
 \newdimen\shaderule \shaderule 5\p@
 \def\shadebox{\dimen0\linewidth \advance\dimen0-20\p@ 
   \advance\dimen0-2\fboxrule \advance\dimen0-\shaderule
@@ -862,6 +884,7 @@
   \hbox{\hbox to \shaderule{\copy0\hss}\kern \z@
   \vrule\@width\wd0\@height\z@\@depth\shaderule\hskip-\shaderule
   \vrule\@width\shaderule\@height\dimen0}}
+\fi
 %    \end{macrocode}
 % \end{environment}
 %

--- a/okumacro.dtx
+++ b/okumacro.dtx
@@ -388,11 +388,17 @@
 % これを使ってキートップ記号を作ります。
 %
 % [2016-07-30] |\keytop| はp\LaTeX のascmacパッケージ(tascmac.sty)でも
-% 定義されていますので，tascmac.styが読み込み済みの場合は定義しないことにします。
+% 定義されていますが，ascmacの定義では周囲と同じファミリのままになっていて，
+% okumacroでは中の文字をサンセリフ体に変更しています。
+%
+% そこで，新たに |\okukeytop| という命令を追加します。これはascmacと干渉せず，
+% 常にサンセリフ体に変更するキートップ記号を出力できます。
+% 一方 |\keytop| は，ascmacを使用しない場合は |\okukeytop| と同じになります
+% が，ascmacを使用する場合はファミリが周囲と同じになります。
+% これはascmacとokumacroの読み込み順に依りません。
 %
 %    \begin{macrocode}
-\expandafter\ifx\csname ver@tascmac.sty\endcsname\relax
-\newcommand{\keytop}[1]{{\leavevmode\kern1pt
+\newcommand{\okukeytop}[1]{{\leavevmode\kern1pt
   \setbox1=\hbox{\normalfont\sffamily [}%
   \dimen1=\ht1
   \removept{\dimen1}{\tempC}%
@@ -414,6 +420,8 @@
     \put(\tempB,\tempC){\oval(\tempA,4)[t]}
     \put(\tempB,0){\makebox(0,0)[b]{\box0}}
   \end{picture}\kern1pt}}
+\expandafter\ifx\csname ver@tascmac.sty\endcsname\relax
+  \newcommand{\keytop}{\okukeytop}
 \fi
 %    \end{macrocode}
 % \end{macro}
@@ -423,10 +431,17 @@
 % リターンキーの記号です。
 %
 % [2016-07-30] |\return| はp\LaTeX のascmacパッケージ(tascmac.sty)でも
-% 定義されていますので，tascmac.styが読み込み済みの場合は定義しないことにします。
+% 定義されていますが，okumacroがリターンのキートップ記号を出力するのに対し，
+% ascmacではリターンの矢印文字{\font\ASCGRP=ascgrp \ASCGRP\char"20}だけ
+% を出す命令になっています。
+%
+% そこで，新たに |\okureturn| という命令を追加します。これはascmacと干渉せず，
+% 常にリターンのキートップ記号\okureturn を出力できます。
+% 一方 |\return| は，ascmacを使用しない場合は |\okureturn| と同じになります
+% が，ascmacを使用する場合は{\font\ASCGRP=ascgrp \ASCGRP\char"20}を出力
+% します。これはascmacとokumacroの読み込み順に依りません。
 %
 %    \begin{macrocode}
-\expandafter\ifx\csname ver@tascmac.sty\endcsname\relax
 \def\RETMARK{{\unitlength=1pt
   \setbox0=\hbox{\normalfont\ttfamily [}%
   \dimen0=\ht0
@@ -437,7 +452,9 @@
     \put(\tempA,1){\line(0,1){\tempB}}
     \put(\tempA,1){\vector(-1,0){\tempA}}
   \end{picture}}}
-\newcommand{\return}{\keytop{\RETMARK}}
+\newcommand{\okureturn}{\okukeytop{\RETMARK}}
+\expandafter\ifx\csname ver@tascmac.sty\endcsname\relax
+  \newcommand{\return}{\okureturn}
 \fi
 %    \end{macrocode}
 % \end{macro}
@@ -738,17 +755,23 @@
 % ただ，screen環境の最初に |[| が来る場合は誤動作しますので，|\relax|
 % か |{}| を入れて誤魔化してください。
 %
-% [2016-07-30] 元になっているp\LaTeX のascmacパッケージ(tascmac.sty)と
-% 衝突しないように，tascmac.styが読み込み済みの場合は定義しないことにします。
-% ascmacパッケージのscreen環境は，オプション引数の数値で角の丸みの大きさを
-% 整数値(0--8)で指定しますが，okumacroパッケージのscreen環境は横の倍率を
-% 指定するという違いがあります。
+% [2016-07-30] 元になっているp\LaTeX のascmacパッケージ(tascmac.sty)の
+% screen環境は，オプション引数の数値で角の丸みの大きさを整数値(0--8)で指定し
+% ますが，okumacroパッケージでは横の倍率を指定するという違いがあります。
+%
+% そこで，新たにokuscreen環境を追加します。これはascmacと干渉せず，常に横の
+% 倍率を指定できるスクリーン風の環境になります。一方screen環境は，ascmacを
+% 使用しない場合はokuscreen環境と同じになりますが，ascmacを使用する場合は
+% ascmacの機能を優先し，角の丸みを指定できるスクリーン風の環境になります。
+% これはascmacとokumacroの読み込み順に依りません。なお，オプション引数を
+% 一切使用しない場合は，どちらも大差ありません。
 %
 %    \begin{macrocode}
 \expandafter\ifx\csname ver@tascmac.sty\endcsname\relax
-\newdimen\@scw
-\newbox\scb@x
-\newenvironment{screen}[1][1]%
+  \newdimen\@scw
+  \newbox\scb@x
+\fi
+\newenvironment{okuscreen}[1][1]%
  {\def\screensc@le{#1}\@scw=\linewidth \advance \@scw by -20pt
   \setbox\scb@x=\hbox\bgroup\begin{minipage}[b]{\@scw}}%
      % または \setbox\scb@x=\vbox\bgroup\advance \linewidth by -20pt \relax
@@ -768,6 +791,8 @@
                  \else\scalebox{\screensc@le}[1]{\box\scb@x}\fi}
     \end{picture}%
   \end{flushleft}}
+\expandafter\ifx\csname ver@tascmac.sty\endcsname\relax
+  \let\screen\okuscreen \let\endscreen\endokuscreen
 \fi
 %    \end{macrocode}
 % \end{environment}
@@ -866,15 +891,18 @@
 % 影付きの箱です。|ascmac.sty| から取りました。
 %
 % [2016-07-30] 元になっているp\LaTeX のascmacパッケージ(tascmac.sty)と
-% 衝突しないように，tascmac.styが読み込み済みの場合は定義しないことにします。
+% 衝突しないように，okumacroのshadebox環境はokushadeboxに改名しました。
+% ただし，ascmacを使用しない場合にも利用できるように，tascmac.styが読み込ま
+% れていない場合はshadebox環境も定義しておきます。
 %
 %    \begin{macrocode}
 \expandafter\ifx\csname ver@tascmac.sty\endcsname\relax
-\newdimen\shaderule \shaderule 5\p@
-\def\shadebox{\dimen0\linewidth \advance\dimen0-20\p@ 
+  \newdimen\shaderule \shaderule 5\p@
+\fi
+\def\okushadebox{\dimen0\linewidth \advance\dimen0-20\p@ 
   \advance\dimen0-2\fboxrule \advance\dimen0-\shaderule
   \setbox\@tempboxa=\hbox\bgroup\minipage{\dimen0}}
-\def\endshadebox{\endminipage\egroup\dimen0=10\p@ \advance\dimen0-\fboxrule
+\def\endokushadebox{\endminipage\egroup\dimen0=10\p@ \advance\dimen0-\fboxrule
   \setbox\@tempboxa=\hbox{\kern\dimen0\unhbox\@tempboxa\kern\dimen0}%
   \setbox0=\vbox{\hrule\@height \fboxrule
   \hbox{\vrule\@width \fboxrule \hskip-\fboxrule
@@ -884,6 +912,8 @@
   \hbox{\hbox to \shaderule{\copy0\hss}\kern \z@
   \vrule\@width\wd0\@height\z@\@depth\shaderule\hskip-\shaderule
   \vrule\@width\shaderule\@height\dimen0}}
+\expandafter\ifx\csname ver@tascmac.sty\endcsname\relax
+  \let\shadebox\okushadebox \let\endshadebox\endokushadebox
 \fi
 %    \end{macrocode}
 % \end{environment}

--- a/okumacro.dtx
+++ b/okumacro.dtx
@@ -70,6 +70,11 @@
 %
 % 以下が実際のマクロ集です。
 %
+% [2016-07-30] 従来は，ascmac→okumacroの順に読み込んだ場合にエラーが出て
+% いましたが，新しい仕様では，ascmacとokumacroの両方を読み込む場合には
+% 「後に読み込んだほう」が勝ちます。
+% 具体的には |\keytop|，|\return|，screen環境，shadebox環境があります。
+%
 %    \begin{macrocode}
 %<*okumacro>
 %    \end{macrocode}
@@ -390,12 +395,12 @@
 % [2016-07-30] |\keytop| はp\LaTeX のascmacパッケージ(tascmac.sty)でも
 % 定義されていますが，ascmacの定義では周囲と同じファミリのままになっていて，
 % okumacroでは中の文字をサンセリフ体に変更しています。
+% 両方のパッケージを読み込む場合は，後に読み込んだほうの定義が勝ちます。
+% okumacroが勝つ場合には常にサンセリフ体に変更するキートップ記号を出力しますし，
+% ascmacが勝つ場合は周囲と同じファミリになります。
 %
-% そこで，新たに |\okukeytop| という命令を追加します。これはascmacと干渉せず，
+% また，新たに |\okukeytop| という命令を追加します。これはascmacと干渉せず，
 % 常にサンセリフ体に変更するキートップ記号を出力できます。
-% 一方 |\keytop| は，ascmacを使用しない場合は |\okukeytop| と同じになります
-% が，ascmacを使用する場合はファミリが周囲と同じになります。
-% これはascmacとokumacroの読み込み順に依りません。
 %
 %    \begin{macrocode}
 \newcommand{\okukeytop}[1]{{\leavevmode\kern1pt
@@ -422,6 +427,8 @@
   \end{picture}\kern1pt}}
 \expandafter\ifx\csname ver@tascmac.sty\endcsname\relax
   \newcommand{\keytop}{\okukeytop}
+\else
+  \renewcommand{\keytop}{\okukeytop}
 \fi
 %    \end{macrocode}
 % \end{macro}
@@ -434,12 +441,12 @@
 % 定義されていますが，okumacroがリターンのキートップ記号を出力するのに対し，
 % ascmacではリターンの矢印文字{\font\ASCGRP=ascgrp \ASCGRP\char"20}だけ
 % を出す命令になっています。
+% 両方のパッケージを読み込む場合は，後に読み込んだほうの定義が勝ちます。
+% okumacroが勝つ場合には\okureturn を出力しますし，
+% ascmacが勝つ場合は{\font\ASCGRP=ascgrp \ASCGRP\char"20}を出力します。
 %
-% そこで，新たに |\okureturn| という命令を追加します。これはascmacと干渉せず，
+% また，新たに |\okureturn| という命令を追加します。これはascmacと干渉せず，
 % 常にリターンのキートップ記号\okureturn を出力できます。
-% 一方 |\return| は，ascmacを使用しない場合は |\okureturn| と同じになります
-% が，ascmacを使用する場合は{\font\ASCGRP=ascgrp \ASCGRP\char"20}を出力
-% します。これはascmacとokumacroの読み込み順に依りません。
 %
 %    \begin{macrocode}
 \def\RETMARK{{\unitlength=1pt
@@ -455,6 +462,8 @@
 \newcommand{\okureturn}{\okukeytop{\RETMARK}}
 \expandafter\ifx\csname ver@tascmac.sty\endcsname\relax
   \newcommand{\return}{\okureturn}
+\else
+  \renewcommand{\return}{\okureturn}
 \fi
 %    \end{macrocode}
 % \end{macro}
@@ -758,13 +767,13 @@
 % [2016-07-30] 元になっているp\LaTeX のascmacパッケージ(tascmac.sty)の
 % screen環境は，オプション引数の数値で角の丸みの大きさを整数値(0--8)で指定し
 % ますが，okumacroパッケージでは横の倍率を指定するという違いがあります。
+% 両方のパッケージを読み込む場合は，後に読み込んだほうの定義が勝ちます。
+% screen環境は，okumacroが勝つ場合には横の倍率を指定できる
+% スクリーン風の環境になりますし，ascmacが勝つ場合は角の丸みを指定できる
+% スクリーン風の環境になります。
 %
-% そこで，新たにokuscreen環境を追加します。これはascmacと干渉せず，常に横の
-% 倍率を指定できるスクリーン風の環境になります。一方screen環境は，ascmacを
-% 使用しない場合はokuscreen環境と同じになりますが，ascmacを使用する場合は
-% ascmacの機能を優先し，角の丸みを指定できるスクリーン風の環境になります。
-% これはascmacとokumacroの読み込み順に依りません。なお，オプション引数を
-% 一切使用しない場合は，どちらも大差ありません。
+% また，新たにokuscreen環境を追加します。これはascmacと干渉せず，常に横の
+% 倍率を指定できるスクリーン風の環境になります。
 %
 %    \begin{macrocode}
 \expandafter\ifx\csname ver@tascmac.sty\endcsname\relax
@@ -791,9 +800,7 @@
                  \else\scalebox{\screensc@le}[1]{\box\scb@x}\fi}
     \end{picture}%
   \end{flushleft}}
-\expandafter\ifx\csname ver@tascmac.sty\endcsname\relax
-  \let\screen\okuscreen \let\endscreen\endokuscreen
-\fi
+\let\screen\okuscreen \let\endscreen\endokuscreen
 %    \end{macrocode}
 % \end{environment}
 %
@@ -891,9 +898,11 @@
 % 影付きの箱です。|ascmac.sty| から取りました。
 %
 % [2016-07-30] 元になっているp\LaTeX のascmacパッケージ(tascmac.sty)と
-% 衝突しないように，okumacroのshadebox環境はokushadeboxに改名しました。
-% ただし，ascmacを使用しない場合にも利用できるように，tascmac.styが読み込ま
-% れていない場合はshadebox環境も定義しておきます。
+% 衝突しないように，新しい仕様では，ascmacとokumacroの両方を読み込む場合には
+% 「後に読み込んだほう」が勝ちます。
+%
+% また，新たにokushadebox環境を追加します。これはascmacと干渉せず，常に
+% okumacro流の定義になります。
 %
 %    \begin{macrocode}
 \expandafter\ifx\csname ver@tascmac.sty\endcsname\relax
@@ -912,9 +921,7 @@
   \hbox{\hbox to \shaderule{\copy0\hss}\kern \z@
   \vrule\@width\wd0\@height\z@\@depth\shaderule\hskip-\shaderule
   \vrule\@width\shaderule\@height\dimen0}}
-\expandafter\ifx\csname ver@tascmac.sty\endcsname\relax
-  \let\shadebox\okushadebox \let\endshadebox\endokushadebox
-\fi
+\let\shadebox\okushadebox \let\endshadebox\endokushadebox
 %    \end{macrocode}
 % \end{environment}
 %


### PR DESCRIPTION
#30 の修正を作ってみました。

- `\keytop`、`\return`、screen 環境、shadebox 環境を oku… の接頭辞付にリネーム。
- tascmac.sty が読み込み済みでない場合は、oku… の定義を元の名称にコピー。

これで、okumacro と ascmac を両方読み込む場合、読み込み順に依らず ascmac の定義が優先される（エラーにならない）ことになります。一方で、okumacro 流の定義も oku… という名称で利用できます。（[ZR さんの bxascmac と bxokumacro の関係](http://zrbabbler.sp.land.to/bxptool.html#sec-bxokumacro)に近いです）

ついでに、圏点の上シフト量を 0.63zw から 0.75zw に直しておきました。