### PR TITLE
jsclasses.dtx: add autodetect-engine option

### DIFF
--- a/jsclasses.dtx
+++ b/jsclasses.dtx
@@ -38,7 +38,7 @@
 %<*driver>
 \ProvidesFile{jsclasses.dtx}
 %</driver>
-  [2016/10/08 okumura, texjporg]
+  [2016/11/09 okumura, texjporg]
 %<*driver>
 \documentclass{jsarticle}
 \usepackage{doc}
@@ -312,6 +312,8 @@
 % [2016-10-08] \texttt{slide} オプションは article 以外では使い物にならなかったので，
 % 簡単のため article のみで使えるオプションとしました。
 %
+% [2016-11-09] pLaTeX / upLaTeX を自動判別するオプション \texttt{autodetect-engine} を新設しました。
+%
 %    \begin{macrocode}
 \newcommand{\@ptsize}{0}
 \newif\ifjsc@mag\jsc@magtrue
@@ -549,10 +551,13 @@
 \jisfontfalse
 \newif\if@jsc@uplatex
 \@jsc@uplatexfalse
+\newif\if@jsc@autodetect
+\@jsc@autodetectfalse
 \DeclareOption{mingoth}{\mingothtrue}
 \DeclareOption{winjis}{\winjistrue}
 \DeclareOption{jis}{\jisfonttrue}
 \DeclareOption{uplatex}{\@jsc@uplatextrue\winjisfalse}
+\DeclareOption{autodetect-engine}{\@jsc@autodetecttrue}
 \def\jsc@JYn{\if@jsc@uplatex JY2\else JY1\fi}
 \def\jsc@JTn{\if@jsc@uplatex JT2\else JT1\fi}
 \def\jsc@pfx@{\if@jsc@uplatex u\else \fi}
@@ -638,6 +643,10 @@
 %
 %    \begin{macrocode}
 \ifnum \ifx\ucs\@undefined\z@\else\ucs"3000 \fi ="3000
+  \if@jsc@autodetect
+    \ClassInfo\jsc@clsname{Autodetected engine: upLaTeX}
+    \@jsc@uplatextrue
+  \fi
   \if@jsc@uplatex\else
     \ClassError\jsc@clsname
       {You are running upLaTeX.\MessageBreak
@@ -647,6 +656,10 @@
     \@jsc@uplatextrue
   \fi
 \else
+  \if@jsc@autodetect
+    \ClassInfo\jsc@clsname{Autodetected engine: pLaTeX}
+    \@jsc@uplatexfalse
+  \fi
   \if@jsc@uplatex
     \ClassError\jsc@clsname
       {You are running pLaTeX.\MessageBreak


### PR DESCRIPTION
bxjscls にある `autodetect-engine` オプションが jscls にもあってほしいという[意見がありました](https://twitter.com/wtsnjp/status/796247172425465856)ので，叩き台を作ってみました。いかがでしょうか。