### PR TITLE
jsclasses.dtx: Fix #45

### DIFF
--- a/jsclasses.dtx
+++ b/jsclasses.dtx
@@ -5370,8 +5370,8 @@
 \def\@@inhibitglue{%
   \expandafter\expandafter\expandafter\jsc@inhibitglue\expandafter\meaning\expandafter\@let@token\KANJI@CHARACTER\relax\jsc@end}
 \expandafter\def\expandafter\jsc@inhibitglue\expandafter#\expandafter1\KANJI@CHARACTER#2#3\jsc@end{%
-  \def\@tempa{#1}%
-  \ifx\@tempa\@empty
+  \def\jsc@tempa{#1}%
+  \ifx\jsc@tempa\@empty
     \ifnum\the\inhibitxspcode`#2=2\relax
       \inhibitglue
     \fi


### PR DESCRIPTION
#45 の原因を調べたところ，単に `\@tempa` という名称がかぶったことが問題のようでした。
そこで，名前空間を分けるべくプレフィックスを付けて `\jsc@tempa` としました。