### PR TITLE
okumacro.dtx: Add more macros for zenkaku-dash

### DIFF
--- a/okumacro.dtx
+++ b/okumacro.dtx
@@ -373,6 +373,23 @@
 \def\――{―\kern-.5zw―\kern-.5zw―}
 %    \end{macrocode}
 %
+% [2016-12-04] \pLaTeX で通るコードが \upLaTeX で通らなくなることを防ぐために，u\pLaTeX の場合にはU+FF0D，U+2014で定義したものも別途用意しました。
+%
+%    \begin{macrocode}
+\ifx\ucs\@undefined\else
+  \begingroup
+    \kansujichar1="FF0D
+    \kansujichar2="2014
+    \expandafter\expandafter\expandafter\gdef
+    \expandafter\csname\expandafter\kansuji\expandafter1%
+    \expandafter\endcsname\kansuji1{―\kern-.5zw―\kern-.5zw―}
+    \expandafter\expandafter\expandafter\gdef
+    \expandafter\csname\expandafter\kansuji\expandafter2%
+    \expandafter\endcsname\kansuji2{―\kern-.5zw―\kern-.5zw―}
+  \endgroup
+\fi
+%    \end{macrocode}
+%
 % \end{macro}
 % \end{macro}
 %


### PR DESCRIPTION
以前話題になった[全角ダーシ問題](https://twitter.com/aminophen/status/791885147595378688)について。JIS と Unicode の変換に伴う pLaTeX と upLaTeX の非互換性問題です。

```tex
\documentclass[autodetect-engine]{jsarticle}
\usepackage{okumacro}
\typeout{\meaning\−}% U+2212
\typeout{\meaning\－}% U+FF0D
\typeout{\meaning\—}% U+2014
\typeout{\meaning\―}% U+2015
\begin{document}
\end{document}
```

このコードを pLaTeX で処理すると

```tex
macro:－->―\kern -.5zw―\kern -.5zw―
macro:－->―\kern -.5zw―\kern -.5zw―
macro:―->―\kern -.5zw―\kern -.5zw―
macro:―->―\kern -.5zw―\kern -.5zw―
```

となるのに対し，upLaTeX で処理すると

```tex
macro:−->―\kern -.5zw―\kern -.5zw―
undefined
undefined
macro:―->―\kern -.5zw―\kern -.5zw―
```

となってしまいます。

この結果，pLaTeX で通っていたコードが upLaTeX で通らなくなる，という事態が起こり，ユーザ側には入力しているダッシュの違いについて神経質になることが要求されてしまいます。

特にMac版ATOKは，U+2212 / U+FF0D, U+2014 / U+2015 のどちらか片方しか入力できない（一方を入力しても他方に強制変換される，「WindowsのUnicodeを使用する」がONのときには 2212→FF0D および2014→2015，OFFのときはその逆）という[困った問題](http://togetter.com/li/675493)があり，この制御が難しいので厄介です。

この厄介な問題を避けるため，upLaTeX でコンパイルした場合には，U+FF0D，U+2014 にも同じ内容のマクロが定義されるように okumacro に加えてみました。