### PR TITLE
Do not add empty page after part if openany

### DIFF
--- a/jsclasses.dtx
+++ b/jsclasses.dtx
@@ -3415,13 +3415,20 @@
 % 両面印刷のときは白ページを追加します。
 % 二段組のときには，二段組に戻します。
 %
+% [2016-12-13] \texttt{openany} のときには白ページが追加されるのは変なので，
+% その場合は追加しないようにしました。このバグは\LaTeX では
+% classes.dtx v1.4b (2000/05/19)
+% で修正されています。
+%
 %    \begin{macrocode}
 %<*book>
 \def\@endpart{\vfil\newpage
   \if@twoside
+   \if@openright %% added (2016/12/13)
     \null
     \thispagestyle{empty}%
     \newpage
+   \fi %% added (2016/12/13)
   \fi
   \if@restonecol
     \twocolumn


### PR DESCRIPTION
[先日](https://github.com/texjporg/jsclasses/pull/44#issuecomment-261998163)と [forum:2088#p12260](http://oku.edu.mie-u.ac.jp/tex/mod/forum/discuss.php?d=2088#p12260) にも書いた openany の古いバグが残存している話です。

openany オプションを使用しているにもかかわらず Part のところで空ページが入ります。

~~~~ tex
\documentclass[openany]{jsbook}
\begin{document}
\part{A}
\chapter{I}
\part{B}
Look at the page numbers.
\end{document}
~~~~

バグだと思われるなら直していいと思いますので、そのコードです。