### PR TITLE
okumacro.dtx: Add ghost to \kenten

### DIFF
--- a/okumacro.dtx
+++ b/okumacro.dtx
@@ -176,17 +176,22 @@
 % [2016-07-30] ルビと圏点の高さを合わせるつもりでしたが，間違って
 % 上シフト量を0.63zwとしていましたので，正しい値0.75zwに直しました。
 %
+% [2017-03-11] 「前後の欧文文字との間に |\xkanjiskip| が入らない」
+% 「後ろの禁則処理が効かない」問題を解決するための処理を追加。
+%
 %    \begin{macrocode}
 \def\kenten#1{%
-  \ifvmode\leavevmode\else\hskip\kanjiskip\fi
+  \okumacro@zsp
+  \kern-1zw\relax
   \setbox1=\hbox to \z@{・\hss}%
   \ht1=.63zw
-  \@kenten#1\end}
-\def\@kenten#1{%
+  \@kenten#1\end
+  \kern-1zw\relax\okumacro@zsp}
+\def\@kenten#1#2{%
   \ifx#1\end \let\next=\relax \else
-    \raise.75zw\copy1\nobreak #1\hskip\kanjiskip\relax
+    \raise.75zw\copy1\nobreak #1\ifx#2\end\else\hskip\kanjiskip\relax\fi
     \let\next=\@kenten
-  \fi\next}
+  \fi\next#2}
 %    \end{macrocode}
 % \end{macro}
 %


### PR DESCRIPTION
okumacro パッケージが提供する `\kenten` には，

* 前後に欧文文字が隣接するときに `\xkanjiskip` が入らない。
* 後ろの禁則処理が効かない

という問題がありましたので，和文ゴースト処理を用いて修正してみました。

# 検証コード

```tex
\documentclass{jsarticle}
\usepackage{okumacro}
\begin{document}
A保毛保毛B\par
A\kenten{保毛保毛}B

\fbox{\parbox{7zw}{%
私は「保毛保毛」です。\par
私は「\kenten{保毛保毛}」です。}}
\end{document}
```

# 従来の組版結果

<img width="244" alt="2017-03-11 23 09 07" src="https://cloud.githubusercontent.com/assets/6186180/23823992/c881d8dc-06b1-11e7-8542-9b86961ec886.png">

# 修正後の組版結果

<img width="245" alt="2017-03-11 23 14 07" src="https://cloud.githubusercontent.com/assets/6186180/23823997/d89f170c-06b1-11e7-80b9-681649808e84.png">
