### PR TITLE
\tableofcontentsのLeaders

### DIFF
--- a/jsclasses.dtx
+++ b/jsclasses.dtx
@@ -5046,7 +5046,7 @@
 % |\@tempdima| を |\@lnumwidth| に変えています。
 %
 %    \begin{macrocode}
-\def\jsTocLine{\leaders\hbox{$\m@th \mkern \@dotsep mu\hbox{.}\mkern \@dotsep mu$}\hfill
+\def\jsTocLine{\leaders\hbox{$\m@th \mkern \@dotsep mu\hbox{.}\mkern \@dotsep mu$}\hfill}
 \def\@dottedtocline#1#2#3#4#5{\ifnum #1>\c@tocdepth \else
   \vskip \z@ \@plus.2\jsc@mpt
   {\leftskip #2\relax \rightskip \@tocrmarg \parfillskip -\rightskip

--- a/jsclasses.dtx
+++ b/jsclasses.dtx
@@ -5046,6 +5046,7 @@
 % |\@tempdima| を |\@lnumwidth| に変えています。
 %
 %    \begin{macrocode}
+\def\jsTocLine{\leaders\hbox{$\m@th \mkern \@dotsep mu\hbox{.}\mkern \@dotsep mu$}\hfill
 \def\@dottedtocline#1#2#3#4#5{\ifnum #1>\c@tocdepth \else
   \vskip \z@ \@plus.2\jsc@mpt
   {\leftskip #2\relax \rightskip \@tocrmarg \parfillskip -\rightskip
@@ -5055,8 +5056,7 @@
    \@lnumwidth #3\relax
    \advance\leftskip \@lnumwidth \null\nobreak\hskip -\leftskip
     {#4}\nobreak
-    \leaders\hbox{$\m@th \mkern \@dotsep mu\hbox{.}\mkern \@dotsep 
-       mu$}\hfill \nobreak\hb@xt@\@pnumwidth{%
+    \jsTocLine \nobreak\hb@xt@\@pnumwidth{%
          \hfil\normalfont \normalcolor #5}\par}\fi}
 %    \end{macrocode}
 % \end{macro}


### PR DESCRIPTION
[\tableofcontentsのLeaders](https://github.com/texjporg/jsclasses/issues/67)で提案したものです。

`\def\jsTocLine{\leaders\hbox{$\m@th \mkern \@dotsep mu\hbox{.}\mkern \@dotsep mu$}\hfill`と定義し，`\@dottedtocline`の中で呼び出すようにしました。

いろいろと教えて下さった@doraTeXさん，ありがとうございました。