### PR TITLE
okumacro.dtx: depth should be taken into account

### DIFF
--- a/okumacro.dtx
+++ b/okumacro.dtx
@@ -849,7 +849,9 @@
  {\end{minipage}\egroup
   \dimen0=\linewidth \removept{\dimen0}{\hsPT}%
   \divide \dimen0 by 2 \removept{\dimen0}{\hhsPT}%
-  \dimen0=\ht\scb@x \advance \dimen0 by 10pt
+  \dimen0=\dp\scb@x \advance \dimen0 by 5pt
+  \removept{\dimen0}{\hdxPT}%
+  \advance \dimen0 by \ht\scb@x \advance \dimen0 by 5pt
   \removept{\dimen0}{\htxPT}%
   \begin{flushleft}
     \vspace{6.5pt}%
@@ -858,7 +860,7 @@
       \put(0,0){\line(0,1){\htxPT}}
       \put(\hsPT,0){\line(0,1){\htxPT}}
       \put(\hhsPT,0){\oval(\hsPT,10)[b]}
-      \put(10,5){\ifdim\screensc@le pt=1pt \box\scb@x
+      \put(10,\hdxPT){\ifdim\screensc@le pt=1pt \box\scb@x
                  \else\scalebox{\screensc@le}[1]{\box\scb@x}\fi}
     \end{picture}%
   \end{flushleft}}

--- a/okumacro.dtx
+++ b/okumacro.dtx
@@ -12,7 +12,7 @@
 %   http://oku.edu.mie-u.ac.jp/~okumura/
 %
 %<okumacro>\NeedsTeXFormat{pLaTeX2e}
-%<okumacro>\ProvidesPackage{okumacro}[2017/10/04 okumura, texjporg]
+%<okumacro>\ProvidesPackage{okumacro}[2018/06/11 okumura, texjporg]
 %<*driver>
 \documentclass{jsarticle}
 \usepackage{doc}
@@ -832,6 +832,11 @@
 % また，新たにokuscreen環境を追加します。これはascmacと干渉せず，常に横の
 % 倍率を指定できるスクリーン風の環境になります。
 %
+% [2018-06-11] 2017/10/04版までは，枠の中身の深さを考慮していなかったので，
+% 表(tabular)や深さのある数式を囲むと枠からはみ出していました。この問題を
+% 修正しましたが，なるべく既存文書のレイアウトが変わらないように，通常の
+% テキストの深さ分だけ引いておきました（|!| と印をつけた部分）。
+%
 %    \begin{macrocode}
 \expandafter\ifx\csname ver@tascmac.sty\endcsname\relax
   \newdimen\@scw
@@ -850,8 +855,10 @@
   \dimen0=\linewidth \removept{\dimen0}{\hsPT}%
   \divide \dimen0 by 2 \removept{\dimen0}{\hhsPT}%
   \dimen0=\dp\scb@x \advance \dimen0 by 5pt
+  \advance \dimen0 by -.5\cdp %% !
   \removept{\dimen0}{\hdxPT}%
   \advance \dimen0 by \ht\scb@x \advance \dimen0 by 5pt
+  \advance \dimen0 by -.5\cdp %% !
   \removept{\dimen0}{\htxPT}%
   \begin{flushleft}
     \vspace{6.5pt}%

--- a/okumacro.sty
+++ b/okumacro.sty
@@ -24,7 +24,7 @@
   \epTeXinputencoding utf8 % ^^A added (2017-10-04)
 \fi
 \NeedsTeXFormat{pLaTeX2e}
-\ProvidesPackage{okumacro}[2017/10/04 okumura, texjporg]
+\ProvidesPackage{okumacro}[2018/06/11 okumura, texjporg]
 \providecommand{\rubyfamily}{}
 \def\kanjistrut{\iftdir
   \vrule \@height0.5zw \@depth0.5zw \@width\z@
@@ -328,8 +328,10 @@
   \dimen0=\linewidth \removept{\dimen0}{\hsPT}%
   \divide \dimen0 by 2 \removept{\dimen0}{\hhsPT}%
   \dimen0=\dp\scb@x \advance \dimen0 by 5pt
+  \advance \dimen0 by -.5\cdp %% !
   \removept{\dimen0}{\hdxPT}%
   \advance \dimen0 by \ht\scb@x \advance \dimen0 by 5pt
+  \advance \dimen0 by -.5\cdp %% !
   \removept{\dimen0}{\htxPT}%
   \begin{flushleft}
     \vspace{6.5pt}%

--- a/okumacro.sty
+++ b/okumacro.sty
@@ -327,7 +327,9 @@
  {\end{minipage}\egroup
   \dimen0=\linewidth \removept{\dimen0}{\hsPT}%
   \divide \dimen0 by 2 \removept{\dimen0}{\hhsPT}%
-  \dimen0=\ht\scb@x \advance \dimen0 by 10pt
+  \dimen0=\dp\scb@x \advance \dimen0 by 5pt
+  \removept{\dimen0}{\hdxPT}%
+  \advance \dimen0 by \ht\scb@x \advance \dimen0 by 5pt
   \removept{\dimen0}{\htxPT}%
   \begin{flushleft}
     \vspace{6.5pt}%
@@ -336,7 +338,7 @@
       \put(0,0){\line(0,1){\htxPT}}
       \put(\hsPT,0){\line(0,1){\htxPT}}
       \put(\hhsPT,0){\oval(\hsPT,10)[b]}
-      \put(10,5){\ifdim\screensc@le pt=1pt \box\scb@x
+      \put(10,\hdxPT){\ifdim\screensc@le pt=1pt \box\scb@x
                  \else\scalebox{\screensc@le}[1]{\box\scb@x}\fi}
     \end{picture}%
   \end{flushleft}}


### PR DESCRIPTION
[Twitter](https://twitter.com/maehrm/status/1002784334636433408) で知った事案ですが，「okumacro パッケージの screen 環境で表を囲むとはみ出す」というのがあります。同名の screen 環境は ascmac パッケージにもありますが，そっちは問題ありません。

この原因は okumacro 版が「深さ」を考慮していないからなので，修正コードを書いてみました。テストケースは以下です。容易に想像がつく通り，表じゃない普通のテキストを囲んだ場合も組版結果が変わってきますが，私は直した方がいいのではないかと思っています。

```` tex
\documentclass{article}
\usepackage{okumacro}

\makeatletter
%%% 従来のコード
\newenvironment{oldokuscreen}[1][1]%
 {\def\screensc@le{#1}\@scw=\linewidth \advance \@scw by -20pt
  \dimen1=#1\p@\relax
  \@tempcnta=\dimen1\relax
  \@tempcntb=65536\relax
  \divide\@scw by \@tempcnta
  \multiply\@scw by \@tempcntb
  \setbox\scb@x=\hbox\bgroup\begin{minipage}[b]{\@scw}}%
     % または \setbox\scb@x=\vbox\bgroup\advance \linewidth by -20pt \relax
 {\end{minipage}\egroup
  \dimen0=\linewidth \removept{\dimen0}{\hsPT}%
  \divide \dimen0 by 2 \removept{\dimen0}{\hhsPT}%
  \dimen0=\ht\scb@x \advance \dimen0 by 10pt
  \removept{\dimen0}{\htxPT}%
  \begin{flushleft}
    \vspace{6.5pt}%
    \begin{picture}(\hsPT,\htxPT)
      \put(\hhsPT,\htxPT){\oval(\hsPT,10)[t]}
      \put(0,0){\line(0,1){\htxPT}}
      \put(\hsPT,0){\line(0,1){\htxPT}}
      \put(\hhsPT,0){\oval(\hsPT,10)[b]}
      \put(10,5){\ifdim\screensc@le pt=1pt \box\scb@x
                 \else\scalebox{\screensc@le}[1]{\box\scb@x}\fi}
    \end{picture}%
  \end{flushleft}}
%%% 改修してみたコード
\renewenvironment{okuscreen}[1][1]%
 {\def\screensc@le{#1}\@scw=\linewidth \advance \@scw by -20pt
  \dimen1=#1\p@\relax
  \@tempcnta=\dimen1\relax
  \@tempcntb=65536\relax
  \divide\@scw by \@tempcnta
  \multiply\@scw by \@tempcntb
  \setbox\scb@x=\hbox\bgroup\begin{minipage}[b]{\@scw}}%
     % または \setbox\scb@x=\vbox\bgroup\advance \linewidth by -20pt \relax
 {\end{minipage}\egroup
  \dimen0=\linewidth \removept{\dimen0}{\hsPT}%
  \divide \dimen0 by 2 \removept{\dimen0}{\hhsPT}%
  \dimen0=\dp\scb@x \advance \dimen0 by 5pt
  \removept{\dimen0}{\hdxPT}%
  \advance \dimen0 by \ht\scb@x \advance \dimen0 by 5pt
  \removept{\dimen0}{\htxPT}%
  \begin{flushleft}
    \vspace{6.5pt}%
    \begin{picture}(\hsPT,\htxPT)
      \put(\hhsPT,\htxPT){\oval(\hsPT,10)[t]}
      \put(0,0){\line(0,1){\htxPT}}
      \put(\hsPT,0){\line(0,1){\htxPT}}
      \put(\hhsPT,0){\oval(\hsPT,10)[b]}
      \put(10,\hdxPT){\ifdim\screensc@le pt=1pt \box\scb@x
                 \else\scalebox{\screensc@le}[1]{\box\scb@x}\fi}
    \end{picture}%
  \end{flushleft}}
\makeatother

\begin{document}

%% 古い定義（問題がさほど目立たないが，上下が不均等になっている）
\begin{oldokuscreen}
あいうえお
\end{oldokuscreen}

\clearpage

%% 新しい定義（上下が均等）
\begin{okuscreen}
あいうえお
\end{okuscreen}

\clearpage

%% 古い定義（表がはみ出す）
\begin{oldokuscreen}
\begin{tabular}{|c|c|c|}
\hline
テスト & テスト & テスト \\
テスト & テスト & テスト \\
テスト & テスト & テスト \\
テスト & テスト & テスト \\
\hline
\end{tabular}
\end{oldokuscreen}

%% 新しい定義（OK）
\begin{okuscreen}
\begin{tabular}{|c|c|c|}
\hline
テスト & テスト & テスト \\
テスト & テスト & テスト \\
テスト & テスト & テスト \\
テスト & テスト & テスト \\
\hline
\end{tabular}
\end{okuscreen}

\end{document}
````