### PR TITLE
hagakiオプション

### DIFF
--- a/jsclasses.dtx
+++ b/jsclasses.dtx
@@ -289,6 +289,9 @@
 \DeclareOption{executivepaper}{%
   \setlength\paperheight {10.5in}%
   \setlength\paperwidth  {7.25in}}
+\DeclareOption{hagaki}{%
+  \setlength\paperheight {148mm}%
+  \setlength\paperwidth  {100mm}}
 %    \end{macrocode}
 %
 % \paragraph{横置き}


### PR DESCRIPTION
TeXで暑中見舞いや年賀状を書きたい方もいらっしゃると思ったので，日本語用文書の標準クラスファイルに`hagaki`オプションがあっても良いのではないかと考えました。